### PR TITLE
Added support to parse trees from a specified root context

### DIFF
--- a/promval/__init__.py
+++ b/promval/__init__.py
@@ -2,7 +2,7 @@ from promval.parser.PromQLLexer import PromQLLexer
 from promval.parser.PromQLParser import PromQLParser
 from promval.parser.PromQLParserListener import PromQLParserListener
 
-from antlr4 import ParseTreeWalker, InputStream, CommonTokenStream
+from antlr4 import ParseTreeWalker, ParserRuleContext, InputStream, CommonTokenStream
 from antlr4.error.ErrorListener import ErrorListener
 
 from promval.error import PromQLSyntaxError
@@ -18,9 +18,12 @@ class MyErrorListener(ErrorListener):
 
 class ParseWalker(PromQLParserListener):
     def _execute(self, promql):
-        walker = ParseTreeWalker()
         tree = self._parse(promql)
-        walker.walk(self, tree)
+        self._walk(tree)
+
+    def _walk(self, ctx: ParserRuleContext):
+        walker = ParseTreeWalker()
+        walker.walk(self, ctx)
 
     def _parse(self, promql):
         input_stream = InputStream(promql)

--- a/promval/extractor.py
+++ b/promval/extractor.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from antlr4 import ParserRuleContext
 from promval import ParseWalker, PromQLParser
 from promval.types import Label
 

--- a/promval/subtree_extractor.py
+++ b/promval/subtree_extractor.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from antlr4 import ParserRuleContext
+from promval import ParseWalker, PromQLParser
+
+
+class SubtreeExtractor(ParseWalker):
+    items: List = []
+
+    def extract(self, ctx: ParserRuleContext):
+        self._walk(ctx)
+        items = self.items.copy()
+        self.items.clear()
+        return items
+
+class AggregationGroupSubExtractor(SubtreeExtractor):
+    def enterAggregation(self, ctx: PromQLParser.AggregationContext) -> None:
+        agg_ctx, labels = self.extract_labels(ctx)
+        if agg_ctx and labels:
+            self.items.append((agg_ctx, labels))
+
+class MetricSubExtractor(SubtreeExtractor):
+    def enterInstantSelector(self, ctx: PromQLParser.InstantSelectorContext) -> None:
+        metric_name = ctx.METRIC_NAME().getText()
+        self.items.append(metric_name)

--- a/tests/test_subtree_extractor.py
+++ b/tests/test_subtree_extractor.py
@@ -1,0 +1,48 @@
+
+from promval.subtree_extractor import AggregationGroupSubExtractor, MetricSubExtractor
+from promval import ParseWalker, PromQLParser
+
+def test_aggregation_group_subextractor():
+    expr = """
+        avg by (first, second)(metric{label='foo'})
+    """
+    root = ParseWalker()._parse(expr)
+    extractor = AggregationGroupSubExtractor()
+    items = extractor.extract(root)
+    assert isinstance(items[0][0], PromQLParser.ByContext)
+    assert items[0][1] == ["first", "second"]
+
+
+def test_aggregation_group_subextractor_multiple():
+    expr = """
+        avg by (first, second)(metric{label='foo'})
+        and
+        avg without (third, fourth)(metric{label='bar'})
+    """
+    ctx = ParseWalker()._parse(expr)
+    left, right = ctx.vectorOperation().vectorOperation()
+    extractor = AggregationGroupSubExtractor()
+    items_left = extractor.extract(left)
+    items_right = extractor.extract(right)
+    assert isinstance(items_left[0][0], PromQLParser.ByContext) and isinstance(items_right[0][0], PromQLParser.WithoutContext)
+    assert items_left[0][1] == ["first", "second"] and items_right[0][1] == ["third", "fourth"]
+
+
+def test_aggregation_group_subextractor_no_agg():
+    expr = """
+        count(metric{label='thing'})
+    """
+    ctx = ParseWalker()._parse(expr)
+    extractor = AggregationGroupSubExtractor()
+    items = extractor.extract(ctx)
+    assert items == []
+
+
+def test_metric_subextractor():
+    expr = """
+        avg by (first, second)(metric{label='thing', other!='stuff'}) / thing{ass='grass'}
+    """
+    ctx = ParseWalker()._parse(expr)
+    extractor = MetricSubExtractor()
+    items = extractor.extract(ctx)
+    assert items == ["metric", "thing"]


### PR DESCRIPTION
This exposes the `_walk()` function of the `ParseWalker` so that classes which extend it can optionally traverse the parse tree from a specified context, rather than just parsing the expression and always starting at the root.

This is useful when wanting to implement validators or extractors that need to verify certain conditions in all of their child trees. (applicable use case in the PR mentioned below)